### PR TITLE
Made Image hotspots usable in Course Presentation 

### DIFF
--- a/library.json
+++ b/library.json
@@ -163,6 +163,11 @@
       "machineName": "H5PEditor.RadioSelector",
       "majorVersion": 1,
       "minorVersion": 0
+    },
+	{
+      "machineName": "H5P.QuestionSet",
+      "majorVersion": 1,
+      "minorVersion": 8
     }
   ]
 }

--- a/library.json
+++ b/library.json
@@ -165,9 +165,9 @@
       "minorVersion": 0
     },
 	{
-      "machineName": "H5P.QuestionSet",
+      "machineName": "H5P.ImageHotspots",
       "majorVersion": 1,
-      "minorVersion": 8
+      "minorVersion": 3
     }
   ]
 }


### PR DESCRIPTION
Image Hotspots can be used in Course Presentation.
However, **the UI of the pop-up elements is improper**. It needs to be relatively positioned when used inside Course Presentation.
