### PR TITLE
swapped icons for singlechoiceset and multichoice

### DIFF
--- a/styles/toolbar.css
+++ b/styles/toolbar.css
@@ -157,7 +157,7 @@
   content: "\e994";
 }
 .h5p-dragnbar-multichoice-button:before {
-  content: "\e993";
+  content: "\e603";
 }
 .h5p-dragnbar-summary-button:before {
   content: "\e992";
@@ -182,7 +182,7 @@
   content: "\e602";
 }
 .h5p-dragnbar-singlechoiceset-button:before {
-  content: "\e603";
+  content: "\e993";
 }
 .h5p-dragnbar-dialogcards-button:before {
   content: "\e900";


### PR DESCRIPTION
It seems that the icons for singlechoiceset and multichoice need swapping.

Unicode 0xe993 represents radio buttons that don't make sense for multiple choice settings.
Unicode 0xe603 represents checks and crosses that rather make sense for multiple choice settings.