### PR TITLE
Remove appear.in dependency

### DIFF
--- a/library.json
+++ b/library.json
@@ -150,11 +150,6 @@
       "minorVersion": 0
     },
     {
-      "machineName": "H5P.AppearIn",
-      "majorVersion": 1,
-      "minorVersion": 0
-    },
-    {
       "machineName": "H5P.Dialogcards",
       "majorVersion": 1,
       "minorVersion": 8

--- a/styles/toolbar.css
+++ b/styles/toolbar.css
@@ -127,7 +127,6 @@
 .h5p-dragnbar-audio-button:before,
 .h5p-dragnbar-video-button:before,
 .h5p-dragnbar-more-button:before,
-.h5p-dragnbar-appearin-button:before,
 .h5p-dragnbar-twitteruserfeed-button:before,
 .h5p-dragnbar-interactivevideo-button:before,
 .h5p-dragnbar-chart-button:before {
@@ -170,9 +169,6 @@
 }
 .h5p-dragnbar-twitteruserfeed-button:before {
   content: "\f099";
-}
-.h5p-dragnbar-appearin-button:before {
-  content: "\f086";
 }
 .h5p-dragnbar-more-button:before {
   content: "\f142";


### PR DESCRIPTION
Was removed from Course Presentation in 2017 (cmp. https://github.com/h5p/h5p-course-presentation/commit/e374bfdae3022b9b928ad782c629dcd7e8ab9f33#diff-37bb91b5340ccc62195bb5c612571bc4b7799d8217cd48b8face008142e2e07c)