### PR TITLE
Set new subContentId for content of cloned slide

### DIFF
--- a/scripts/cp-editor.js
+++ b/scripts/cp-editor.js
@@ -294,6 +294,10 @@ H5PEditor.CoursePresentation.prototype.appendTo = function ($wrapper) {
     .next()
     .click(function () {
       var newSlide = H5P.cloneObject(that.params.slides[that.cp.$current.index()], true);
+
+      // Set new subContentId for cloned contents
+      that.resetSubContentId(newSlide.elements);
+
       newSlide.keywords = [];
       that.addSlide(newSlide);
       H5P.ContinuousText.Engine.run(that);
@@ -341,6 +345,30 @@ H5PEditor.CoursePresentation.prototype.appendTo = function ($wrapper) {
   });
 
   this.updateSlidesSidebar();
+};
+
+/**
+ * Recursively reset all subContentIds.
+ *
+ * @param {object} params Parameters to parse.
+ */
+H5PEditor.CoursePresentation.prototype.resetSubContentId = function (params) {
+  const that = this;
+
+  if (Array.isArray(params)) {
+    params.forEach(function (param) {
+      that.resetSubContentId(param);
+    });
+  }
+  else if (typeof params === 'object') {
+    if (params.library && params.subContentId) {
+      params.subContentId = H5P.createUUID();
+    }
+
+    for (param in params) {
+      that.resetSubContentId(params[param]);
+    }
+  }
 };
 
 /**


### PR DESCRIPTION
Currently, when slides are cloned, the content instances on that slide do not get a fresh subcontent id. This can cause trouble for customizations that e.g. evaluate the subcontent ids as part of xAPI statements.

When merged in, cloning slides will include setting a fresh subcontent id for all subcontents of the cloned slide.