### PR TITLE
JI-5884 update h5p-table dependency version

### DIFF
--- a/library.json
+++ b/library.json
@@ -2,7 +2,7 @@
   "title": "Course Presentation Editor",
   "majorVersion": 1,
   "minorVersion": 25,
-  "patchVersion": 11,
+  "patchVersion": 12,
   "runnable": 0,
   "machineName": "H5PEditor.CoursePresentation",
   "author": "Joubel",
@@ -77,7 +77,7 @@
     {
       "machineName": "H5P.Table",
       "majorVersion": 1,
-      "minorVersion": 1
+      "minorVersion": 2
     },
     {
       "machineName": "H5P.Video",


### PR DESCRIPTION
The cke5 branch for h5p-table is at version 1.2.
https://github.com/h5p/h5p-table/blob/JI-5193-migrate-ckeditor-v5/library.json
Updated library.json so that it uses h5p-table 1.2.