### PR TITLE
Update H5P.InteractiveVideo dependency version

### DIFF
--- a/library.json
+++ b/library.json
@@ -127,7 +127,7 @@
     {
       "machineName": "H5P.InteractiveVideo",
       "majorVersion": 1,
-      "minorVersion": 26
+      "minorVersion": 27
     },
     {
       "machineName": "H5P.MarkTheWords",


### PR DESCRIPTION
fixing [#313](https://github.com/h5p/h5p-course-presentation/issues/313) impossible to install H5P.CoursePresentation from Hub because of error raised "Missing required library H5P.InteractiveVideo 1.26"